### PR TITLE
Added quotes to VPN_FILE variable

### DIFF
--- a/killswitch.sh
+++ b/killswitch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 trap ctrl_c INT
-VPN_FILE=$1
+VPN_FILE="$1"
 
 function check_permission() {
 	if test " `id -u`" != " 0"
@@ -11,7 +11,7 @@ function check_permission() {
 }
 
 function check_argument() {
-	if [ -z $VPN_FILE ]
+	if [ -z "$VPN_FILE" ]
 		then
 		echo "First argument must be VPN file(.ovpn)"
 		exit 1
@@ -29,15 +29,15 @@ function config() {
 
 	#Get the VPN IP, PORT and PROTOCOL from the VPN file
 	echo "Detecting your VPN server address..."
-	IP=`cat $VPN_FILE | grep "remote " | awk '{print $2}'`
+	IP=`cat "$VPN_FILE" | grep "remote " | awk '{print $2}'`
 	echo "Using IP "$IP
 
 	echo "Detecting your VPN port..."
-	PORT=`cat $VPN_FILE | grep "remote " | awk '{print $3}'`
+	PORT=`cat "$VPN_FILE" | grep "remote " | awk '{print $3}'`
 	echo "Using port "$PORT
 
 	echo "Detecting your VPN protocol..."
-	PROTOCOL=`cat $VPN_FILE | grep "proto " | awk '{print $2}'`
+	PROTOCOL=`cat "$VPN_FILE" | grep "proto " | awk '{print $2}'`
 	echo "Using protocol "$PROTOCOL
 }
 
@@ -66,7 +66,7 @@ function reconnect() {
 	#Kill older openvpn processes to avoid creating new tunnels
 	kill `ps -ef | grep "openvpn $VPN_FILE" | grep -v "grep" | awk '{print $2}'` > /dev/null 2>&1
 	#Start openvpn
-	openvpn $VPN_FILE & 
+	openvpn "$VPN_FILE" & 
 }
 
 #Check every 20 seconds if VPN goes down, then reconnect it


### PR DESCRIPTION
Allows for filenames with spaces in them. Otherwise, cat would fail when given them.